### PR TITLE
Update target frameworks and cleanup

### DIFF
--- a/LICC.Console/LICC.Console.csproj
+++ b/LICC.Console/LICC.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Platforms>AnyCPU;x86</Platforms>
-    <TargetFrameworks>netstandard2.0;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LICC.Test/LICC.Test.csproj
+++ b/LICC.Test/LICC.Test.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LICC.Test/Parsing/LexerTest.cs
+++ b/LICC.Test/Parsing/LexerTest.cs
@@ -1,4 +1,4 @@
-﻿using LICC.API;
+using LICC.API;
 using LICC.Internal.LSF.Parsing;
 using LICC.Internal.LSF.Parsing.Data;
 using NUnit.Framework;
@@ -23,6 +23,11 @@ namespace LICC.Test.Parsing
             }
 
             public bool FileExists(string path) => true;
+
+            public void CreateFile(string path)
+            {
+                // Nothing to do here. This class represents a read-only file that does not have to be created.
+            }
 
             public StreamReader OpenRead(string path)
             {

--- a/LICC.Test/Parsing/LexerTest.cs
+++ b/LICC.Test/Parsing/LexerTest.cs
@@ -1,13 +1,10 @@
-using LICC.API;
+﻿using LICC.API;
 using LICC.Internal.LSF.Parsing;
 using LICC.Internal.LSF.Parsing.Data;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace LICC.Test.Parsing
 {

--- a/LICC.Test/ShellTest.cs
+++ b/LICC.Test/ShellTest.cs
@@ -3,11 +3,7 @@ using LICC.Internal;
 using Moq;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace LICC.Test
 {

--- a/LICC.Test/ValueConverterTest.cs
+++ b/LICC.Test/ValueConverterTest.cs
@@ -1,9 +1,5 @@
 ﻿using NUnit.Framework;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace LICC.Test
 {

--- a/LICC/BuiltInCommands.cs
+++ b/LICC/BuiltInCommands.cs
@@ -1,6 +1,5 @@
 ﻿using LICC.Internal;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/LICC/Directory.Build.props
+++ b/LICC/Directory.Build.props
@@ -1,0 +1,6 @@
+﻿<Project>
+  <PropertyGroup>
+    <OutputPath>..\bin\</OutputPath>
+    <BaseIntermediateOutputPath>..\obj\</BaseIntermediateOutputPath>
+  </PropertyGroup>
+</Project>

--- a/LICC/Internal/CommandExecutor.cs
+++ b/LICC/Internal/CommandExecutor.cs
@@ -1,7 +1,5 @@
-﻿using LICC.API;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace LICC.Internal
 {

--- a/LICC/Internal/CommandFinder.cs
+++ b/LICC/Internal/CommandFinder.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 
 namespace LICC.Internal
 {

--- a/LICC/LICC.csproj
+++ b/LICC/LICC.csproj
@@ -6,9 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <OutputPath>..\bin\</OutputPath>
-    <BaseIntermediateOutputPath>..\obj\</BaseIntermediateOutputPath>
-    <TargetFrameworks>netstandard2.0;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,10 +14,6 @@
     <EmbeddedResource Remove="obj\**" />
     <None Remove="**/*.meta" />
     <None Remove="obj\**" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/Playground/Playground.csproj
+++ b/Playground/Playground.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Playground/Program.cs
+++ b/Playground/Program.cs
@@ -1,14 +1,6 @@
-using LICC;
-using LICC.API;
+﻿using LICC;
 using LICC.Console;
-using LICC.Internal.LSF.Parsing;
-using LICC.Internal.LSF.Runtime;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Threading;
 
 namespace Playground
 {

--- a/Playground/Program.cs
+++ b/Playground/Program.cs
@@ -1,4 +1,4 @@
-﻿using LICC;
+using LICC;
 using LICC.API;
 using LICC.Console;
 using LICC.Internal.LSF.Parsing;
@@ -38,7 +38,7 @@ namespace Playground
             LConsole.WriteLine($"Hello {num}, {str} ({str?.GetType()})", ConsoleColor.Blue);
 
             if (num == 42)
-                Console.SwitchFrontend(new PlainTextConsoleFrontend());
+                FrontendManager.Frontend = new PlainTextConsoleFrontend();
 
             return new TestClass();
         }


### PR DESCRIPTION
Primarily this PR updates the project to `netstandard2.1` and `net9.0`.
This is to reduce dependency version clashes of newer net core frameworks and LICC.

A test and the Playground project have been fixed. Both got broken by commits of the past.
Note: The tests are not fully functional yet, the `ShellTest` got broken by commit (2c361f37df2f227f647cd2e2ba3ea5b9130715de).

Also removing unused imports.